### PR TITLE
Merge staging into main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: staging

--- a/.github/workflows/compile-and-test.yml
+++ b/.github/workflows/compile-and-test.yml
@@ -2,7 +2,7 @@ name: Check for successful compilation
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: ["main", "staging"]
 
 jobs:
   compile-and-test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "nexus"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "clap",
  "fern",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,18 +1649,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,18 +1474,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.200"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.200"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ rocket = { version = "0.5.0", features = ["json"] }
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.200", features = ["derive"] }
 serde_json = "1.0.116"
-thiserror = "1.0.60"
+thiserror = "1.0.61"
 tokio = { version = "1.37.0", features = ["full"] }
 uuid = { version = "1.8.0", features = ["v4", "fast-rng", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ reqwest = "0.12.4"
 rocket = { version = "0.5.0", features = ["json"] }
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.200", features = ["derive"] }
-serde_json = "1.0.116"
+serde_json = "1.0.117"
 thiserror = "1.0.61"
 tokio = { version = "1.37.0", features = ["full"] }
 uuid = { version = "1.8.0", features = ["v4", "fast-rng", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ log = { version = "0.4.21", features = ["serde"] }
 reqwest = "0.12.4"
 rocket = { version = "0.5.0", features = ["json"] }
 semver = { version = "1.0.23", features = ["serde"] }
-serde = { version = "1.0.200", features = ["derive"] }
+serde = { version = "1.0.202", features = ["derive"] }
 serde_json = "1.0.117"
 thiserror = "1.0.61"
 tokio = { version = "1.37.0", features = ["full"] }


### PR DESCRIPTION
This merges the latest patches of Dependabot into a new release. Also, CI/CD has been adapted to the new main/staging strategy.